### PR TITLE
style: adjust chat background and navbar color

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,6 +1,6 @@
 /* Layout base */
 html, body { height: 100%; }
-body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background-color: hsl(0, 0%, 42%); }
 .agent-root { position: fixed; left: 0; right: 0; bottom: 0; top: 72px; }
 
 /* Pre-chat overlay */

--- a/assets/css/chat.css
+++ b/assets/css/chat.css
@@ -1,5 +1,5 @@
 :root{
-  --bg:#0f1115;
+  --bg:hsl(0, 0%, 42%);
   --panel:#1a1d24;
   --bubble-bot:#23262d;
   --bubble-user:#0d6efd; /* azul bootstrap-like */
@@ -20,7 +20,7 @@ body.app{
 
 .app__topbar{
   display:flex;justify-content:space-between;align-items:center;
-  padding:10px 14px;border-bottom:1px solid var(--border);background:var(--panel);
+  padding:10px 14px;border-bottom:1px solid var(--border);background:#124a93;
   position:sticky;top:0;z-index:10;
 }
 .brand{display:flex;gap:10px;align-items:center;font-weight:600}
@@ -73,3 +73,4 @@ body.app{
 .typing span:nth-child(2){animation-delay:.2s}
 .typing span:nth-child(3){animation-delay:.4s}
 @keyframes blink{0%,80%,100%{opacity:.2}40%{opacity:1}}
+

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -38,7 +38,7 @@
     const directLine = CopilotStudioWebChat.createConnection(client, { showTyping: true });
 
     const styleOptions = {
-      backgroundColor: "transparent",
+      backgroundColor: "hsl(0, 0%, 42%)",
       bubbleBackground: "#2f2f2f",
       bubbleBorderColor: "#3a3a3a",
       bubbleTextColor: "#ffffff",

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
     <!-- Topbar simple (opcional, dejalo si ya tenés el tuyo) -->
     <!--
-    <header id="topbar" style="height:72px;background:#083ba3;color:#fff;display:flex;align-items:center;justify-content:center">
+    <header id="topbar" style="height:72px;background:#124a93;color:#fff;display:flex;align-items:center;justify-content:center">
       <h1 style="font-size:18px;margin:0">Línea Directa</h1>
     </header>
     -->


### PR DESCRIPTION
## Summary
- set chat background to 42% gray
- change navbar color to #124a93

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ae39d4288333afe9efc9e094fcd9