### PR TITLE
Add ELEDE logo to top navbar

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3,6 +3,21 @@ html, body { height: 100%; }
 body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background-color: hsl(0, 0%, 42%); }
 .agent-root { position: fixed; left: 0; right: 0; bottom: 0; top: 72px; }
 
+/* Header navbar */
+#topbar {
+  height: 72px;
+  background: #124a93;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+#topbar img {
+  height: 33px;
+  width: auto;
+  margin-right: 33px;
+}
+
 /* Pre-chat overlay */
 .prechat-overlay{ position:fixed; inset:0; display:grid; place-items:center; background:rgba(0,0,0,.65); z-index:30 }
 .prechat-card{ width:min(520px,92vw); background:#111827; color:#e5e7eb; border:1px solid #2b2b2b; border-radius:16px; padding:20px; box-shadow:0 10px 30px rgba(0,0,0,.35) }

--- a/index.html
+++ b/index.html
@@ -8,12 +8,10 @@
 </head>
 <body>
 
-    <!-- Topbar simple (opcional, dejalo si ya tenés el tuyo) -->
-    <!--
-    <header id="topbar" style="height:72px;background:#124a93;color:#fff;display:flex;align-items:center;justify-content:center">
-      <h1 style="font-size:18px;margin:0">Línea Directa</h1>
-    </header>
-    -->
+  <!-- Topbar con logo de ELEDE -->
+  <header id="topbar">
+    <img src="assets/img/logo_elede.png" alt="ELEDE" />
+  </header>
 
   <!-- Contenedor donde se renderiza Web Chat -->
   <div id="webchat-host" class="agent-root" aria-label="Asistente"></div>


### PR DESCRIPTION
## Summary
- Add header with ELEDE logo at top right
- Style header and logo with blue background and spacing

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b0a43558833390c3ca82cd1092a7