### PR TITLE
Eliminar header duplicado y logo de ELEDE

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,22 +1,7 @@
 /* Layout base */
 html, body { height: 100%; }
 body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background-color: hsl(0, 0%, 42%); }
-.agent-root { position: fixed; left: 0; right: 0; bottom: 0; top: 72px; }
-
-/* Header navbar */
-#topbar {
-  height: 72px;
-  background: #124a93;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-}
-
-#topbar img {
-  height: 33px;
-  width: auto;
-  margin-right: 33px;
-}
+.agent-root { position: fixed; left: 0; right: 0; bottom: 0; top: 0; }
 
 /* Pre-chat overlay */
 .prechat-overlay{ position:fixed; inset:0; display:grid; place-items:center; background:rgba(0,0,0,.65); z-index:30 }

--- a/index.html
+++ b/index.html
@@ -7,14 +7,8 @@
   <link rel="stylesheet" href="assets/css/app.css" />
 </head>
 <body>
-
-  <!-- Topbar con logo de ELEDE -->
-  <header id="topbar">
-    <img src="assets/img/logo_elede.png" alt="ELEDE" />
-  </header>
-
-  <!-- Contenedor donde se renderiza Web Chat -->
-  <div id="webchat-host" class="agent-root" aria-label="Asistente"></div>
+    <!-- Contenedor donde se renderiza Web Chat -->
+    <div id="webchat-host" class="agent-root" aria-label="Asistente"></div>
 <!DOCTYPE html><html><body><iframe src="https://copilotstudio.microsoft.com/environments/60b9ea0e-2763-e584-bde3-1c89cb713ae4/bots/cr63c_agent/webchat?__version__=2" frameborder="0" style="width: 100%; height: 100%;"></iframe></body></html>
   <!-- Pre-chat (Nombre, Email, PIN) -->
   <div id="prechat" class="prechat-overlay" aria-hidden="false">


### PR DESCRIPTION
## Summary
- Quita el header azul y el logo propios para usar el encabezado por defecto de ELEDE
- Ajusta el contenedor del chat para ocupar todo el alto disponible

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b5bae63883338647ede907643429