### PR TITLE
Add Caddy config for frontend and API proxy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,12 @@
+{
+    email admin@example.com
+}
+
+{$DOMAIN} {
+    root * build
+    encode gzip
+    handle /api/* {
+        reverse_proxy localhost:5000
+    }
+    file_server
+}


### PR DESCRIPTION
## Summary
- add Caddyfile to serve frontend build, proxy /api/* to localhost:5000, and enable gzip

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b1c61ea0848333b98178c50d51c477