### PR TITLE
Add backend with dotenv configuration

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "backend",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^17.2.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^17.2.1"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,23 @@
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
+
+const http = require('http');
+
+const port = process.env.PORT || 3000;
+const connectionString = process.env.COPILOT_CONNECTION_STRING;
+const directLineSecret = process.env.COPILOT_DIRECTLINE_SECRET;
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ status: 'ok' }));
+});
+
+server.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+  if (connectionString) {
+    console.log('COPILOT_CONNECTION_STRING loaded');
+  }
+  if (directLineSecret) {
+    console.log('COPILOT_DIRECTLINE_SECRET loaded');
+  }
+});


### PR DESCRIPTION
## Summary
- add Node backend server that loads COPILOT environment variables via dotenv
- ensure .env files are ignored to keep secrets out of version control

## Testing
- `node backend/server.js`

------
https://chatgpt.com/codex/tasks/task_e_68b1cae3a9288333b13073537abb3b2b