### PR TITLE
Add Direct Line REST module and backend switch

### DIFF
--- a/backend/chat.js
+++ b/backend/chat.js
@@ -1,0 +1,25 @@
+const directline = require('./directline');
+const sdk = require('./sdk');
+
+// Determina si se usa Direct Line o SDK basándose en la variable de entorno.
+const USE_DIRECTLINE = process.env.USE_DIRECTLINE === 'true';
+
+/**
+ * Enviar un mensaje al bot usando Direct Line o el SDK.
+ * @param {object} options - opciones necesarias para cada modo.
+ * @param {string} options.text - mensaje a enviar.
+ * @param {string} [options.secret] - secreto de Direct Line.
+ * @param {string} [options.conversationId] - ID de la conversacion (Direct Line).
+ * @param {string} [options.token] - token de conversacion (Direct Line).
+ * @param {object} [options.client] - instancia del SDK.
+ */
+async function sendMessage(options) {
+  if (USE_DIRECTLINE) {
+    const { secret, conversationId, text } = options;
+    return directline.sendMessage(secret, conversationId, text);
+  }
+  const { client, text } = options;
+  return sdk.sendMessage(client, text);
+}
+
+module.exports = { USE_DIRECTLINE, sendMessage };

--- a/backend/directline.js
+++ b/backend/directline.js
@@ -1,0 +1,61 @@
+const BASE_URL = 'https://directline.botframework.com/v3/directline';
+
+/**
+ * Crear una nueva conversación usando Direct Line REST.
+ * @param {string} secret - Direct Line secret.
+ * @returns {Promise<object>} Datos de la conversación.
+ */
+async function createConversation(secret) {
+  const res = await fetch(`${BASE_URL}/conversations`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${secret}` }
+  });
+  if (!res.ok) {
+    throw new Error(`DirectLine error ${res.status}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+/**
+ * Enviar un mensaje a una conversación existente.
+ * @param {string} secret - Direct Line secret.
+ * @param {string} conversationId - ID de la conversación.
+ * @param {string} text - Texto del mensaje.
+ */
+async function sendMessage(secret, conversationId, text) {
+  const res = await fetch(`${BASE_URL}/conversations/${conversationId}/activities`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${secret}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ type: 'message', text })
+  });
+  if (!res.ok) {
+    throw new Error(`DirectLine error ${res.status}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+/**
+ * Obtener actividades nuevas de una conversación.
+ * @param {string} secret - Direct Line secret.
+ * @param {string} conversationId - ID de la conversación.
+ * @param {string} [watermark] - Ultimo watermark recibido.
+ */
+async function getMessages(secret, conversationId, watermark) {
+  const url = `${BASE_URL}/conversations/${conversationId}/activities` + (watermark ? `?watermark=${watermark}` : '');
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${secret}` }
+  });
+  if (!res.ok) {
+    throw new Error(`DirectLine error ${res.status}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+module.exports = {
+  createConversation,
+  sendMessage,
+  getMessages
+};

--- a/backend/sdk.js
+++ b/backend/sdk.js
@@ -1,0 +1,12 @@
+/**
+ * Enviar un mensaje utilizando el SDK de Agents/Copilot.
+ * Este módulo es un simple contenedor; se asume que el cliente del SDK
+ * ya fue instanciado y pasado como argumento.
+ */
+async function sendMessage(client, text) {
+  // En una implementación real, se usaría el cliente del SDK para enviar
+  // la actividad correspondiente al bot.
+  return client.postActivity({ type: 'message', text });
+}
+
+module.exports = { sendMessage };


### PR DESCRIPTION
## Summary
- add Direct Line REST helper module
- allow backend to switch between SDK and Direct Line via USE_DIRECTLINE

## Testing
- `node --check backend/directline.js`
- `node --check backend/sdk.js`
- `node --check backend/chat.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1caec30148333bc500a838fb4daa5